### PR TITLE
Error reporting and url formatting fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,8 +39,9 @@ def search(arg):
     #   format=json
     #   SITE=at_sRNA  (indicates small RNA for Arabidopsis thaliana)
     # We will expose all of SITE=at_sRNA as one endpoint called at_sRNA.
-    url = 'http://mpss.udel.edu/web/php/pages/abundances.php?SITE=at_sRNA&chrnum=%d&beg=%d&end=%d&format=json' \
-        % (input_chr,input_beg,input_end)
+    url = ('http://mpss.udel.edu/web/php/pages/abundances.php?SITE=at_sRNA'
+           '&chrnum={chr}&beg={beg}&end={end}&format=json'
+           .format(chr=input_chr, beg=input_beg, end=input_end))
 
     rqst = requests.get(url)
 

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,7 +1,7 @@
 # file: metadata.yml
 
 ---
-name: at_sRNA
+name: at_srna
 version: 0.1
 type: query
 main_module: main.py


### PR DESCRIPTION
- Communicate errors by raising exceptions
- Fix url formatting. Notice that all arguments (fields in `arg`) are passed as strings, even if they are numbers. If the adapter is expected to operate on them as numbers, an explicit conversion is required (for example `x=int(arg['chr'])`)
