### PR TITLE
Add parameter documentation

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -11,7 +11,8 @@ whitelist:
   - mpss.udel.edu
 endpoints:
   /search:
-    summary: |
+    summary: Search small RNA abundance
+    description: |
       Search small RNA abundance per line for a chromosome "chr"
       in the region defined by "beg" and "end".
     parameters:

--- a/metadata.yml
+++ b/metadata.yml
@@ -9,3 +9,23 @@ url: http://mpss.udel.edu/
 description: 'Arabidopsis thalaiana small RNA abundance per line'
 whitelist:
   - mpss.udel.edu
+endpoints:
+  /search
+    summary: |
+      Search small RNA abundance per line for a chromosome "chr"
+      in the region defined by "beg" and "end".
+    parameters:
+      - name: chr
+        description: Chromosome
+        type: string
+        required: true
+      - name: beg
+        description: Beginning
+        type: integer
+        format: int64
+        required: true
+      - name: end
+        description: End
+        type: integer
+        format: int64
+        required: true

--- a/metadata.yml
+++ b/metadata.yml
@@ -10,7 +10,7 @@ description: 'Arabidopsis thalaiana small RNA abundance per line'
 whitelist:
   - mpss.udel.edu
 endpoints:
-  /search
+  /search:
     summary: |
       Search small RNA abundance per line for a chromosome "chr"
       in the region defined by "beg" and "end".


### PR DESCRIPTION
This pull request adds parameter documentation for the adapter.  An example is registered at 
https://adama-dev.cloudapp.net/community/v0.3/walter/at_srna_v0.1

See sample documentation at: https://adama-dev.cloudapp.net/community/v0.3/walter/at_srna_v0.1/docs/swagger

The documentation works against the instance of Adama at adama-dev.cloudapp.net, but it can also be registered against api.araport.org.  When we update Adama at araport, the documentation will be immediately available.
